### PR TITLE
Update call-to-action link

### DIFF
--- a/_includes/call-to-action.html
+++ b/_includes/call-to-action.html
@@ -4,7 +4,7 @@
             <div class="col-md-8 col-md-offset-2">
               <h2 class="section-heading">Start actively collecting cloud events today!</h2>
               <p>Getting started with Reflex is easy, simply follow our documentation.</p>
-                <a href="https://github.com/cloudmitigator/reflex" class="btn btn-outline btn-xl page-scroll">Reflex Docs</a>
+                <a href="https://docs.cloudmitigator.com/" class="btn btn-outline btn-xl page-scroll">Reflex Docs</a>
                 <div class="badges">
                 </div>
             </div>


### PR DESCRIPTION
Modify call to action to point to the actual reflex docs instead of the reflex-engine github repo.